### PR TITLE
fix(createpci): Remove file extension correctly for files with multiple dots in their names

### DIFF
--- a/pca_op_createpci.py
+++ b/pca_op_createpci.py
@@ -27,7 +27,7 @@ ops = {"+": operator.add,
 
 
 def removeImgExtension(string):
-    return string.split('.')[0]
+    return string.rsplit('.', 1)[0]
 
 
 def addpci(pano, location, rotation):


### PR DESCRIPTION
Files like `pano-2025-03-04_17.23.00.jpg` were accidentally shortened to `pano-2025-03-04_17` via the `removeImgExtension` method.
This meant that if there were multiple files like pano-2025-03-04_17.23.00.jpg (pano-2025-03-04_17.26.00.jpg for example), then only one of them would be imported.

The output of XPhase 360° cameras have this naming convention for their output files, hence the issue.